### PR TITLE
fixed app element not extending beyond screen height

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,5 @@
 .App {
   width: 100vw;
-  height: 100vh;
   background-repeat: no-repeat;
   background-position: center;
   background-attachment: fixed;


### PR DESCRIPTION
this results in the background displaying correctly as before it was not extending all the way down since the content of the page would overflow from the body and html elements